### PR TITLE
Add an option to discover a timestamp from the entire entry

### DIFF
--- a/org-reverse-datetree-test.el
+++ b/org-reverse-datetree-test.el
@@ -92,6 +92,42 @@
         (expect result
                 :to-equal
                 (org-reverse-datetree--encode-time
-                 (list 0 40 15 31 1 2022 nil nil nil)))))))
+                 (list 0 40 15 31 1 2022 nil nil nil)))))
+    (pcase-let ((`(,result-inactive ,result-active)
+                 (with-temp-buffer
+                   (insert-file-contents "test/time.org")
+                   ;; (setq buffer-file-name "test/time.org")
+                   (org-mode)
+                   (goto-char (org-find-property "CUSTOM_ID" "clock-in-heading-1"))
+                   (list (org-reverse-datetree--entry-time-2 '((match :type inactive)))
+                         (org-reverse-datetree--entry-time-2 '((match :type active)))))))
+      (it "matches the first inactive clock"
+        (expect result-inactive
+                :to-equal
+                (org-reverse-datetree--encode-time
+                 (list 0 0 0 10 3 2022 nil nil nil))))
+      (it "matches the first active clock"
+        (expect result-active
+                :to-equal
+                (org-reverse-datetree--encode-time
+                 (list 0 33 15 24 2 2022 nil nil nil)))))
+    (pcase-let ((`(,result-any ,result-default)
+                 (with-temp-buffer
+                   (insert-file-contents "test/time.org")
+                   ;; (setq buffer-file-name "test/time.org")
+                   (org-mode)
+                   (goto-char (org-find-property "CUSTOM_ID" "clock-in-heading-2"))
+                   (list (org-reverse-datetree--entry-time-2 '((match :type any)))
+                         (org-reverse-datetree--entry-time-2 '((match :type nil)))))))
+      (it "matches the first any clock"
+        (expect result-any
+                :to-equal
+                (org-reverse-datetree--encode-time
+                 (list 0 24 12 1 3 2022 nil nil nil))))
+      (it "matches the first inactive clock"
+        (expect result-default
+                :to-equal
+                (org-reverse-datetree--encode-time
+                 (list 0 0 0 10 3 2022 nil nil nil)))))))
 
 (provide 'org-reverse-datetree-test)

--- a/test/time.org
+++ b/test/time.org
@@ -10,3 +10,13 @@ CLOCK: [2022-01-31 Mon 15:40]--[2022-01-31 Mon 16:17] =>  0:37
 :LOGBOOK:
 CLOCK: [2022-01-20 Thu 01:54]--[2022-01-20 Thu 02:05] =>  0:11
 :END:
+* [2022-03-10 Thu]
+:PROPERTIES:
+:CUSTOM_ID: clock-in-heading-1
+:END:
+<2022-02-24 Thu 15:33>
+** <2022-03-01 Tue 12:24>
+:PROPERTIES:
+:CUSTOM_ID: clock-in-heading-2
+:END:
+[2022-03-10 Thu]


### PR DESCRIPTION
Allow a `match` entry in `org-reverse-datetree-entry-time` custom variable, which matches the first match of a timestamp regexp in the entry. If the heading of an entry contains a timestamp, it will be matched.