### PR TITLE
Don't depend on org-time-stamp-formats

### DIFF
--- a/.nomake/flake.lock
+++ b/.nomake/flake.lock
@@ -3,11 +3,11 @@
     "buttercup": {
       "flake": false,
       "locked": {
-        "lastModified": 1648586608,
-        "narHash": "sha256-qGZYc9ECJ28ZjazpGUqY8Z7fdbdWCA0/ujtd0CWD8qA=",
+        "lastModified": 1666814792,
+        "narHash": "sha256-81IWzkLZ1dwxht7mHhQfijheEQ5w9zAaSiY+I3ipiLU=",
         "owner": "jorgenschaefer",
         "repo": "emacs-buttercup",
-        "rev": "f5cbf97e1086441b2d6fa3ea240758b932c7c5e1",
+        "rev": "eaa4b3ccd115a2bb25be98dc637950645d3adbae",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "dash": {
       "flake": false,
       "locked": {
-        "lastModified": 1632096711,
-        "narHash": "sha256-oeIUEe5OGgij6IessN6bmS7re5r+D5BlrU4MOsaK3JE=",
+        "lastModified": 1665650208,
+        "narHash": "sha256-b0dAQPHOv0oZkmkV/0kHqSWwz45W1mWrx1Iv83/M6B0=",
         "owner": "magnars",
         "repo": "dash.el",
-        "rev": "da167c51e9fd167a48d06c7c0ee8e3ac7abd9718",
+        "rev": "3df46d7d9fe74f52a661565888e4d31fd760f0df",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     "org": {
       "flake": false,
       "locked": {
-        "lastModified": 1648740710,
-        "narHash": "sha256-yqLzec7jH1UfR05UVl7KzTtKgOqHz1clSIpUWuiF5AY=",
+        "lastModified": 1665899000,
+        "narHash": "sha256-LE2+QiHxUQ1GIHGHROODWlnJMC3hO/XIaBAq1uiM0zY=",
         "ref": "bugfix",
-        "rev": "64ee5c2c47e0167f4cd4740a8d57731d30d47b68",
-        "revCount": 24629,
+        "rev": "58a46fab0d317ecc106ec5d326ecf04395a30052",
+        "revCount": 24665,
         "type": "git",
         "url": "git://git.sv.gnu.org/emacs/org-mode.git"
       },
@@ -52,11 +52,11 @@
     "org-reverse-datetree": {
       "flake": false,
       "locked": {
-        "lastModified": 1646930854,
-        "narHash": "sha256-oraw+Io/nt24LMAO8RTNyMUMIKSpkP+oaqYuyazZ1ak=",
+        "lastModified": 1668445988,
+        "narHash": "sha256-LqDdiq9OWtv+TqN70/iUkenyKIK5eUVCrxxzGJbNaUw=",
         "owner": "akirak",
         "repo": "org-reverse-datetree",
-        "rev": "c42078f8601b7f600135f66e75246a53c5f9975f",
+        "rev": "67aecbbb55b2e0d1c435e686ac46c37038a981d0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "elisp-helpers": {
       "flake": false,
       "locked": {
-        "lastModified": 1653582233,
-        "narHash": "sha256-AKfLXQeu97IgCp6GXLZoG85cqIoeK/36y/AnJeLq87Y=",
+        "lastModified": 1665027644,
+        "narHash": "sha256-S55qcQBNZcwA2UKRd3Xxv+T9liuWNiGhi2u0GvzYoeo=",
         "owner": "emacs-twist",
         "repo": "elisp-helpers",
-        "rev": "e10097d2666af196664e12d62dd5c355f9e736e7",
+        "rev": "f3ff71386581b89eff58074ec7080c7326a17dca",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     "emacs-ci": {
       "flake": false,
       "locked": {
-        "lastModified": 1658153854,
-        "narHash": "sha256-gFWERhKS30S2RWKhVCmizYwt0aD3/oT+hIJI0WTykWo=",
+        "lastModified": 1665753430,
+        "narHash": "sha256-u3URCMjRV8XnqhL4Dic8SAarom2JOtEmL1oCqB1hqiY=",
         "owner": "purcell",
         "repo": "nix-emacs-ci",
-        "rev": "293a82339fe7529820f363d421343e7b154beb6b",
+        "rev": "c77015eb14b711fcfa33fbe324cd539636ebf220",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1658402513,
-        "narHash": "sha256-wk38v/mbLsOo6+IDmmH1H0ADR87iq9QTTD1BP9X2Ags=",
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "f2ea0f8ff1bce948ccb6b893d15d5ea3efaf1364",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     "gnu-elpa": {
       "flake": false,
       "locked": {
-        "lastModified": 1659114501,
-        "narHash": "sha256-mR/VmNlrxaobhL+Z3Y6FmF7dwr90QS283JG0fAOlqa8=",
+        "lastModified": 1668694731,
+        "narHash": "sha256-cuNw22Rm/JCJAsHMEwGc/fRxxuvENyMBADgQM/qU8u4=",
         "ref": "main",
-        "rev": "db2bd85641001b667f30521737e94019614191c3",
-        "revCount": 397,
+        "rev": "9a5a419fd4236e830bd774e49699cb82cadd2a3a",
+        "revCount": 463,
         "type": "git",
         "url": "https://git.savannah.gnu.org/git/emacs/elpa.git"
       },
@@ -152,11 +152,11 @@
     "melpa": {
       "flake": false,
       "locked": {
-        "lastModified": 1659127569,
-        "narHash": "sha256-0LK3RcuVOEwEzMx8VUj6bn9dHiBu6IPri8O3y/aYqvk=",
+        "lastModified": 1668426712,
+        "narHash": "sha256-qJjlWEtwGRd51SCrSkqPds2GulVLXh3+crNaKLe6FBg=",
         "owner": "melpa",
         "repo": "melpa",
-        "rev": "3046079cbdb80167355a87703327613f41f4b329",
+        "rev": "aa0b80e1ee16d20c38593650f148783d4f93c822",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         "twist": "twist"
       },
       "locked": {
-        "lastModified": 1659247977,
-        "narHash": "sha256-oPISBMp71YbzQixzSTXjpFod2ibJOWiNbeJ6FB4PWeE=",
+        "lastModified": 1668578767,
+        "narHash": "sha256-eBVT9cvD/KVX9JJ+u1WgcA1mTMBivZOsIg5TLw0IERs=",
         "owner": "emacs-twist",
         "repo": "nomake",
-        "rev": "ae8cbd59f5ecdc877d2be4638d5dd0f17fdd4cfa",
+        "rev": "c50030ff5bd8750250cde9c934fcb025de2a749c",
         "type": "github"
       },
       "original": {
@@ -212,11 +212,11 @@
     "package-lint": {
       "flake": false,
       "locked": {
-        "lastModified": 1654587496,
-        "narHash": "sha256-0xByypyCGKf/XCWMbWmggoSGRDXq9QpVuKnhS/uSRug=",
+        "lastModified": 1664814981,
+        "narHash": "sha256-5uza8wm6XKZUnLTp+vLOInTfUnGVGTWF4Dl0b8a72mA=",
         "owner": "purcell",
         "repo": "package-lint",
-        "rev": "70529b2ecba5f3a037be8b2c6ecbca769c64b00e",
+        "rev": "4ea8318c1bf79ccb1b4658d58917bbd9f990c432",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         "fromElisp": "fromElisp"
       },
       "locked": {
-        "lastModified": 1658080432,
-        "narHash": "sha256-cnHsIIN8xHcWqTuhoBcb/OAcbtAXYc3jMsT1ua6Qm44=",
+        "lastModified": 1668522452,
+        "narHash": "sha256-+rSZ1/dhWQjzF2tmTMuI5d5LlRGqLpg+YPPdPZXZ81k=",
         "owner": "emacs-twist",
         "repo": "twist.nix",
-        "rev": "79c97344938a217056ca538a044c0e79a1d59086",
+        "rev": "e793b2b3e91a409ab7cef7def23460f1352df894",
         "type": "github"
       },
       "original": {

--- a/org-reverse-datetree.el
+++ b/org-reverse-datetree.el
@@ -1027,9 +1027,6 @@ A prefix argument FIND-DONE should be treated as in
              (tr-org-odd-levels-only org-odd-levels-only)
              (this-buffer (current-buffer))
              (current-time (current-time))
-             (time (format-time-string
-                    (substring (cdr org-time-stamp-formats) 1 -1)
-                    current-time))
              (file (or (buffer-file-name (buffer-base-buffer))
                        (error "No file associated to buffer")))
              (afile (org-reverse-datetree--archive-file file))
@@ -1040,9 +1037,12 @@ A prefix argument FIND-DONE should be treated as in
                            ((find-buffer-visiting afile))
                            ((find-file-noselect afile))
                            (t (error "Cannot access file \"%s\"" afile))))
-             (archive-time (org-reverse-datetree--encode-time
-                            (org-parse-time-string
-                             (or (org-entry-get nil "CLOSED" t) time)))))
+             (closed (org-entry-get nil "CLOSED" t))
+             (archive-time (if closed
+                               (and (string-match org-ts-regexp-inactive closed)
+                                    (org-reverse-datetree--encode-time
+                                     (org-parse-time-string (match-string 1 closed))))
+                             current-time)))
         (save-excursion
           (org-back-to-heading t)
           ;; Get context information that will be lost by moving the


### PR DESCRIPTION
The default value of org-time-stamp-formats is going to be changed in Org 9.6. It seems generally a bad idea for third-party packages to directly refer to it.

Actually, it is unnecessary to use the variable directly in this package, so I have rewritten the code this way.