### PR TITLE
fix: Skip the property drawer when inserting a new header

### DIFF
--- a/org-reverse-datetree.el
+++ b/org-reverse-datetree.el
@@ -571,6 +571,9 @@ TEXT is a heading text."
   "Insert a pair of KEY and VALUE into the file header."
   (org-with-wide-buffer
    (goto-char (point-min))
+   (when (looking-at org-property-drawer-re)
+     (goto-char (match-end 0))
+     (beginning-of-line 2))
    (if (re-search-forward (concat (rx bol "#+")
                                   (regexp-quote key)
                                   (rx ":" (1+ space)))


### PR DESCRIPTION
In recent versions of Org, an Org file can have a property drawer at its beginning. It seems that per-file keywords must not precede over the property drawer, so the drawer should be skipped when inserting new fields.