### PR TITLE
Bump dependencies

### DIFF
--- a/.nomake/flake.lock
+++ b/.nomake/flake.lock
@@ -35,11 +35,11 @@
     "org": {
       "flake": false,
       "locked": {
-        "lastModified": 1665899000,
-        "narHash": "sha256-LE2+QiHxUQ1GIHGHROODWlnJMC3hO/XIaBAq1uiM0zY=",
+        "lastModified": 1669960764,
+        "narHash": "sha256-5dTYHxz7R9a0CHZFIpA3T5r08naXgme6DcGxsksBcOM=",
         "ref": "bugfix",
-        "rev": "58a46fab0d317ecc106ec5d326ecf04395a30052",
-        "revCount": 24665,
+        "rev": "4564627415b1e609acdddd6e92b33d51c8e427c1",
+        "revCount": 25831,
         "type": "git",
         "url": "git://git.sv.gnu.org/emacs/org-mode.git"
       },
@@ -52,11 +52,11 @@
     "org-reverse-datetree": {
       "flake": false,
       "locked": {
-        "lastModified": 1668445988,
-        "narHash": "sha256-LqDdiq9OWtv+TqN70/iUkenyKIK5eUVCrxxzGJbNaUw=",
+        "lastModified": 1669011971,
+        "narHash": "sha256-hg2KvtwQTpszJbsh7uCf6+ShUXa/0OaIWFX9E747X0w=",
         "owner": "akirak",
         "repo": "org-reverse-datetree",
-        "rev": "67aecbbb55b2e0d1c435e686ac46c37038a981d0",
+        "rev": "127b168960296861f73f8e38247438ebdc575d1e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     "emacs-ci": {
       "flake": false,
       "locked": {
-        "lastModified": 1665753430,
-        "narHash": "sha256-u3URCMjRV8XnqhL4Dic8SAarom2JOtEmL1oCqB1hqiY=",
+        "lastModified": 1666944771,
+        "narHash": "sha256-e2TD8J9bwShyM5YkvjDUSD55OaDV6RauJKU9MthF7jQ=",
         "owner": "purcell",
         "repo": "nix-emacs-ci",
-        "rev": "c77015eb14b711fcfa33fbe324cd539636ebf220",
+        "rev": "54dc89d71e20e01451b33d6c18261916bcef8615",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
     "gnu-elpa": {
       "flake": false,
       "locked": {
-        "lastModified": 1668694731,
-        "narHash": "sha256-cuNw22Rm/JCJAsHMEwGc/fRxxuvENyMBADgQM/qU8u4=",
+        "lastModified": 1669813888,
+        "narHash": "sha256-Rlt6JogHwlOqBHJGmynLmC6bYZElNZgSBXd99b1dbac=",
         "ref": "main",
-        "rev": "9a5a419fd4236e830bd774e49699cb82cadd2a3a",
-        "revCount": 463,
+        "rev": "b162472eb65dee5c38c88cbeac1a43dbfc00d3f3",
+        "revCount": 470,
         "type": "git",
         "url": "https://git.savannah.gnu.org/git/emacs/elpa.git"
       },
@@ -152,11 +152,11 @@
     "melpa": {
       "flake": false,
       "locked": {
-        "lastModified": 1668426712,
-        "narHash": "sha256-qJjlWEtwGRd51SCrSkqPds2GulVLXh3+crNaKLe6FBg=",
+        "lastModified": 1669856792,
+        "narHash": "sha256-en6/IdvqmERcaeS2xAmnc3jHH+I+6wAuDjF8DG7sC84=",
         "owner": "melpa",
         "repo": "melpa",
-        "rev": "aa0b80e1ee16d20c38593650f148783d4f93c822",
+        "rev": "8e2676f0a686e56bd4ac56f79526fcbda37b0e29",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         "twist": "twist"
       },
       "locked": {
-        "lastModified": 1668578767,
-        "narHash": "sha256-eBVT9cvD/KVX9JJ+u1WgcA1mTMBivZOsIg5TLw0IERs=",
+        "lastModified": 1669851494,
+        "narHash": "sha256-lb8NKuOM0r3ILQFGdmXAZD1ZfIxBYGjarplD+e9iO6c=",
         "owner": "emacs-twist",
         "repo": "nomake",
-        "rev": "c50030ff5bd8750250cde9c934fcb025de2a749c",
+        "rev": "d981739893863a3b6208d5f66a47025b1872f449",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         "fromElisp": "fromElisp"
       },
       "locked": {
-        "lastModified": 1668522452,
-        "narHash": "sha256-+rSZ1/dhWQjzF2tmTMuI5d5LlRGqLpg+YPPdPZXZ81k=",
+        "lastModified": 1669657026,
+        "narHash": "sha256-C4XvV9PQ62GPiLVp3jhTL7vfWGve3Dy2NdyFEYFjRKg=",
         "owner": "emacs-twist",
         "repo": "twist.nix",
-        "rev": "e793b2b3e91a409ab7cef7def23460f1352df894",
+        "rev": "275696db46548bf126bbf40e18c739db06a5db19",
         "type": "github"
       },
       "original": {

--- a/org-reverse-datetree.el
+++ b/org-reverse-datetree.el
@@ -4,7 +4,7 @@
 
 ;; Author: Akira Komamura <akira.komamura@gmail.com>
 ;; Version: 0.4.2-pre
-;; Package-Requires: ((emacs "26.1") (dash "2.12") (org "9.3"))
+;; Package-Requires: ((emacs "28.1") (dash "2.19") (org "9.5"))
 ;; Keywords: outlines
 ;; URL: https://github.com/akirak/org-reverse-datetree
 

--- a/org-reverse-datetree.el
+++ b/org-reverse-datetree.el
@@ -363,7 +363,7 @@ tree of the date tree, like a file+olp+datetree target of
                                 (when (not (eq return-type 'default))
                                   (cdr (assq 'default
                                              org-reverse-datetree-show-context-detail)))))
-        (org-show-set-visibility visibility)))))
+        (org-fold-show-set-visibility visibility)))))
 
 ;;;###autoload
 (cl-defun org-reverse-datetree-1 (&optional time
@@ -1006,8 +1006,8 @@ A prefix argument FIND-DONE should be treated as in
 `org-archive-subtree'."
   (interactive "P")
   (require 'org-archive)
-  (unless (fboundp 'org-show-all)
-    (user-error "This function requires `org-show-all' but it is unavailable"))
+  (unless (fboundp 'org-fold-show-all)
+    (user-error "This function requires `org-fold-show-all' but it is unavailable"))
   (if (and (org-region-active-p) org-loop-over-headlines-in-active-region)
       (let ((cl (if (eq org-loop-over-headlines-in-active-region 'start-level)
         	    'region-start-level 'region))
@@ -1103,10 +1103,10 @@ A prefix argument FIND-DONE should be treated as in
                        org-odd-levels-only
                      tr-org-odd-levels-only)))
               (goto-char (point-min))
-              ;; TODO: Find an alternative to `org-show-all'.
-              ;; org-show-all is unavailable in the Org shipped with
+              ;; TODO: Find an alternative to `org-fold-show-all'.
+              ;; org-fold-show-all is unavailable in the Org shipped with
               ;; Emacs 26.3.
-              (org-show-all '(headings blocks))
+              (org-fold-show-all '(headings blocks))
               ;; Paste
               ;; Append to the date tree
               (org-end-of-subtree)


### PR DESCRIPTION
Some functions have been deprecated in Org 9.6 and throws a byte-compile error. Hence I'll drop support for old versions.