### PR TITLE
Remove unecessary use of format when constructing message

### DIFF
--- a/org-reverse-datetree.el
+++ b/org-reverse-datetree.el
@@ -901,7 +901,7 @@ Return the effective time of the target headline."
                      time :return 'rfloc))))
          (heading (nth 4 (org-heading-components))))
     (org-refile nil nil rfloc)
-    (message (format "\"%s\" -> %s" heading (car rfloc)))
+    (message "\"%s\" -> %s" heading (car rfloc))
     time))
 
 (defun org-reverse-datetree-default-entry-time ()


### PR DESCRIPTION
This fixes a bug where message will try and fail to parse the title of the refiled entry as a format string if it contains special characters.