### PR TITLE
Remove redundant refile log

### DIFF
--- a/org-reverse-datetree.el
+++ b/org-reverse-datetree.el
@@ -902,10 +902,8 @@ Return the effective time of the target headline."
                         (find-file-noselect file))
                   (save-excursion
                     (org-reverse-datetree-goto-date-in-file
-                     time :return 'rfloc))))
-         (heading (nth 4 (org-heading-components))))
+                     time :return 'rfloc)))))
     (org-refile nil nil rfloc)
-    (message "\"%s\" -> %s" heading (car rfloc))
     time))
 
 (defun org-reverse-datetree-default-entry-time ()


### PR DESCRIPTION
The latest version of org-refile logs the refile destination in itself, so this logging is redundant. Remove it so the user can see the last message by org-refile function.