### PR TITLE
Add a custom variable to set the default archive location

### DIFF
--- a/README.org
+++ b/README.org
@@ -235,8 +235,11 @@ The following snippet is a naive implementation of a function which migrates ent
 You can archive a tree to a reverse datetree using =org-reverse-datetree-archive-subtree= command.
 It also works on multiple trees in an active region.
 
-The destination is specified in either =REVERSE_DATETREE_ARCHIVE_FILE= property (inherited) or =REVERSE_DATETREE_ARCHIVE_FILE= file header. It should be a file path.
-For now, the target file cannot contain multiple date trees.
+The default destination can be customized by either setting
+=org-reverse-datetree-archive-file= custom variable or
+=REVERSE_DATETREE_ARCHIVE_FILE= property. The value should be a file path. The
+property can be set in an entry property (inherited) or in the file header.
+If none of the them are set, the function interactively prompts for a file name.
 
 From inside =org-agenda=, you can use =org-reverse-datetree-agenda-archive=.
 It doesn't work on bulk entries for now.

--- a/org-reverse-datetree.el
+++ b/org-reverse-datetree.el
@@ -184,6 +184,20 @@ in the Org header."
 
 (make-variable-buffer-local 'org-reverse-datetree-level-formats)
 
+(defcustom org-reverse-datetree-archive-file nil
+  "File name for archiving entries.
+
+This variable is used as the destination of
+`org-reverse-datetree-archive-subtree'.
+
+If the variable is nil, @='REVERSE_DATETREE_ARCHIVE_FILE
+property (either in an Org entry of the header of the Org file) will be
+used instead. If none of the variable is nil, the function will ask for
+a file name via an interactive prompt."
+  :group 'org-reverse-datetree
+  :type '(choice (const nil)
+                 (file :tag "Name of an Org file")))
+
 (defcustom org-reverse-datetree-show-context-detail
   '((default . ancestors))
   "Alist that defines how to show the context of the date entry.
@@ -1022,7 +1036,11 @@ is returned."
   "An org-reverse-datetree equivalent to `org-archive-subtree'.
 
 A prefix argument FIND-DONE should be treated as in
-`org-archive-subtree'."
+`org-archive-subtree'.
+
+To customize the file to which the subtree is archived, set
+`org-reverse-datetree-archive-file' variable or set
+@'REVERSE_DATETREE_ARCHIVE_FILE property in the file header."
   (interactive "P")
   (require 'org-archive)
   (unless (fboundp 'org-fold-show-all)
@@ -1192,7 +1210,8 @@ A prefix argument FIND-DONE should be treated as in
 (defun org-reverse-datetree--archive-file (origin-file)
   "Retrieve the name of the archive file, relative from ORIGIN-FILE."
   (let ((pname "REVERSE_DATETREE_ARCHIVE_FILE"))
-    (or (org-entry-get-with-inheritance pname)
+    (or org-reverse-datetree-archive-file
+        (org-entry-get-with-inheritance pname)
         (org-reverse-datetree--lookup-file-name-header
          pname "Select an archive file: " :abbreviate origin-file))))
 


### PR DESCRIPTION
Implements #74. The variable is not local by default, so the user can customize it to globally set the archive location. This is equivalent to `org-archive-location` variable for the built-in implementation.